### PR TITLE
chore: add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Desktop Servies Store file genereated by MFractors
+.DS_Store


### PR DESCRIPTION
Just de-bloating the repo here and there, slowly but surely. Also a bit annoyed to see the .DS_Store files as well. Bye2 useless files.